### PR TITLE
Also show members in map which entered at least zip or city

### DIFF
--- a/widgets/MapView.php
+++ b/widgets/MapView.php
@@ -105,7 +105,7 @@ class MapView extends Widget {
             return call_user_func($module->getFormatedAddressCallback, $user);
         }
 
-        if (empty($user->profile->zip) || empty($user->profile->city)) {
+        if (empty($user->profile->zip) && empty($user->profile->city)) {
             return null;
         }
 


### PR DESCRIPTION
This small change also shows members in the map which have either entered their zip code **or** their city.
The map APIs can easily handle it if one of those is missing.

Currently one has to enter zip and city to be shown on map and sometimes people don't do that.